### PR TITLE
Reformat document footer text

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -23,8 +23,7 @@
       <div class="l-docs-row" style="padding-top: 3rem">
         <div class="p-notification--information">
           <div class="p-notification__response">
-            <p>Help improve this document <a href="{{ forum_link }}">in the forum</a>.</p>
-            <p>Last updated {{ updated }}.</p>
+            <p>Last updated {{ updated }}. <a href="{{ forum_link }}">Help improve this document in the forum</a>.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #29

QA
--

`./run`, check e.g. http://0.0.0.0:8029/t/configuration-in-snaps/510, see the footer text format has slightly changed.