### PR TITLE
Update footer support links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -126,8 +126,9 @@
             You can contribute to, or report problems with,
             <a class="p-link--external" href="https://bugs.launchpad.net/snapd">snapd</a>,
             <a class="p-link--external" href="https://bugs.launchpad.net/snapcraft">Snapcraft</a>,
+            <a class="p-link--external" href="https://forum.snapcraft.io/c/doc">documentation content</a>
             or
-            <a class="p-link--external" href="https://github.com/canonical-websites/snapcraft.io/issues">this site</a>.
+            <a class="p-link--external" href="https://github.com/canonical-websites/docs.snapcraft.io/issues">this site</a>.
             <br>
             Powered by <a href="https://www.ubuntu.com/kubernetes">the Canonical Distribution of Kubernetes</a>
             ·


### PR DESCRIPTION
Better explain how to contribute to docs.snapcraft.io by mentioning
both the codebase and the forum.

Fixes #52

QA
--

`./run`, go to http://0.0.0.0:8030/t/snap-documentation/3781, read the footer and make sure it makes sense and the links go sensible places.