### PR TITLE
Admonition replacements for note and warning

### DIFF
--- a/templates/_notification.html
+++ b/templates/_notification.html
@@ -1,5 +1,5 @@
-<div class="{{ notification_class }}" id="notification">
-    <p class="p-notification__response">
-      {{ contents | safe }}
-    </p>
+<div class="{{ notification_class }}">
+  <p class="p-notification__response">
+    {{ contents | safe }}
+  </p>
 </div>

--- a/templates/_notification.html
+++ b/templates/_notification.html
@@ -1,0 +1,5 @@
+<div class="{{ notification_class }}" id="notification">
+    <p class="p-notification__response">
+      {{ contents | safe }}
+    </p>
+</div>

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -44,16 +44,32 @@ class NavigationParseError(Exception):
 def _process_html(html):
     """
     Post-process the HTML output from Discourse to
-    remove 'NOTE TO EDITORS' sections
+    remove 'NOTE TO EDITORS' sections.
+
+    We expect these sections to be of the HTML format:
+
+    <aside class="quote no-group">
+      <blockquote>
+        <p>
+          <img title=":construction:" class="emoji" ...>
+          <strong>NOTE TO EDITORS</strong>
+          <img title=":construction:" class="emoji" ...>
+        </p>
+        <p> ... </p>
+      </blockquote>
+    </aside>
     """
 
     soup = BeautifulSoup(html, features="html.parser")
-    notes_to_editors_spans = soup.find_all(text="NOTE TO EDITORS")
+    notes_to_editors_text = soup.find_all(text="NOTE TO EDITORS")
 
     soup = _replace_notifications(soup)
 
-    for span in notes_to_editors_spans:
-        container = span.parent.parent.parent.parent
+    for text in notes_to_editors_text:
+        # If this section is of the expected HTML format,
+        # we should find the <aside> container 4 levels up from
+        # the "NOTE TO EDITORS" text
+        container = text.parent.parent.parent.parent
 
         if container.name == "aside" and "quote" in container.attrs["class"]:
             container.decompose()

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 from requests.exceptions import HTTPError
 from urllib.parse import urlparse
 from canonicalwebteam.http import CachedSession
+from jinja2 import Template
 
 
 # Constants
@@ -34,6 +35,74 @@ class NavigationParseError(Exception):
     def __init__(self, document, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.document = document
+
+
+# Private helper functions
+# ===
+
+
+def _process_html(html):
+    """
+    Post-process the HTML output from Discourse to
+    remove 'NOTE TO EDITORS' sections
+    """
+
+    soup = BeautifulSoup(html, features="html.parser")
+    notes_to_editors_spans = soup.find_all(text="NOTE TO EDITORS")
+
+    soup = _replace_notifications(soup)
+
+    for span in notes_to_editors_spans:
+        container = span.parent.parent.parent.parent
+
+        if container.name == "aside" and "quote" in container.attrs["class"]:
+            container.decompose()
+
+    return str(soup)
+
+
+def _replace_notifications(soup):
+    """
+    Given some BeutifulSoup of a document,
+    replace blockquotes with the appropriate notification markup
+    """
+
+    with open("templates/_notification.html") as notification_file:
+        notification_template = Template(notification_file.read())
+
+    for note in soup.findAll(text=re.compile("ⓘ ")):
+        paragraph = note.parent
+        blockquote = paragraph.parent
+
+        if paragraph.name == "p" and blockquote.name == "blockquote":
+            text_contents = paragraph.encode_contents().decode("utf-8")
+            new_contents = re.sub("^ⓘ ", "", text_contents)
+
+            notification_html = notification_template.render(
+                notification_class="p-notification", contents=new_contents
+            )
+            blockquote.replace_with(
+                BeautifulSoup(notification_html, features="html.parser")
+            )
+
+    for warning in soup.findAll("img", title=":warning:"):
+        paragraph = warning.parent
+        blockquote = paragraph.parent
+
+        if paragraph.name == "p" and blockquote.name == "blockquote":
+            warning.decompose()
+            text_contents = paragraph.encode_contents().decode("utf-8")
+            new_contents = re.sub("^ ", "", text_contents)
+
+            notification_html = notification_template.render(
+                notification_class="p-notification--caution",
+                contents=new_contents,
+            )
+            blockquote.replace_with(
+                BeautifulSoup(notification_html, features="html.parser")
+            )
+
+    return soup
 
 
 class DiscourseDocs:
@@ -128,26 +197,6 @@ class DiscourseDocs:
     # Private helper methods
     # ===
 
-    def _process_html(self, html):
-        """
-        Post-process the HTML output from Discourse to
-        remove 'NOTE TO EDITORS' sections
-        """
-
-        soup = BeautifulSoup(html, features="html.parser")
-        notes_to_editors_spans = soup.find_all(text="NOTE TO EDITORS")
-
-        for span in notes_to_editors_spans:
-            container = span.parent.parent.parent.parent
-
-            if (
-                container.name == "aside"
-                and "quote" in container.attrs["class"]
-            ):
-                container.decompose()
-
-        return str(soup)
-
     def _parse_document_topic(self, topic):
         """
         Parse a topic object retrieve from Discourse
@@ -166,7 +215,7 @@ class DiscourseDocs:
 
         return {
             "title": topic["title"],
-            "body_html": self._process_html(
+            "body_html": _process_html(
                 topic["post_stream"]["posts"][0]["cooked"]
             ),
             "updated": humanize.naturaltime(


### PR DESCRIPTION
Replace note and warning blockquotes with the [proper vanilla notifications](https://docs.vanillaframework.io/en/patterns/notification) markup & styling.

Fixes #35

QA
--

`./run`, and go to http://0.0.0.0:8030/t/service-management/3965 and check both the default note and the warning style vanilla notifications are successfully presented. Also go to e.g. http://0.0.0.0:8030/t/snap-documentation/3781 to check pages without admonitions still work.