### PR TITLE
Update Talisker to 0.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ humanize==0.5.1
 python-dateutil==2.7.5
 gunicorn[gevent]
 prometheus_client==0.3.1
-talisker==0.10.2
-celery==4.2.1
+talisker==0.11.0
 responses==0.10.4
 
 # Development dependencies


### PR DESCRIPTION
Talisker version 0.11.0 was released, resolving the unspecified dependency on celery.

So I'm updating Talisker and removing Celery from our direct dependencies.

QA
--

`./run`, check the site works