### PR TITLE
Renovate: Group minor dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,7 @@
       "extends": [":automergeMinor"]
     },
     {
-      "packagePatterns": [
-        "*"
-      ],
+      "packagePatterns": ["*"],
       "minor": {
         "groupName": "all non-major dependencies",
         "groupSlug": "all-minor-patch"

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,15 @@
     {
       "depTypeList": ["devDependencies"],
       "extends": [":automergeMinor"]
+    },
+    {
+      "packagePatterns": [
+        "*"
+      ],
+      "minor": {
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
+      }
     }
   ]
 }


### PR DESCRIPTION
We have a lot of projects, so we get a lot of Renovate PRs. I propose that we use this setting for our default Renovate settings - group minor dependencies into one PR. Since they'll often work fine together, we can review them together. In the odd occasion that they don't work fine, I don't think it's beyond our ken to manually try updating them one-by-one to discover the issue.

(see https://renovatebot.com/docs/presets-group/)