### PR TITLE
Add Intercom to the developer docs pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -60,17 +60,14 @@
             app_id: "s1rasgdr"
           };
           var use_intercom = false;
-          document.querySelectorAll('.p-sidenav__body ul a').forEach(function(a) {
-            if (a.pathname == location.pathname) {
-              var node = a;
-              // Lists can be nested, so climb until just under the nav element
-              while (node.parentNode && node.parentNode.nodeName != "NAV") node = node.parentNode;
-              if (node.previousElementSibling.textContent == 'Publishing') {
-                // Use Intercom if this page is under Publishing in the TOC
-                use_intercom = true;
-              }
+          var activeNav = document.querySelector('.p-sidenav__body ul a.is-active');
+          if (activeNav) {
+            var ul = activeNav.closest("nav > ul");
+            if (ul && ul.previousSibling.textContent === "Publishing") {
+              // Use Intercom if this page is under Publishing in the TOC
+              use_intercom = true;
             }
-          });
+          }
           if (use_intercom) {
             (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
           }

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,27 @@
               anchor.classList.add('is-active');
             }
           });
+
+          // Enable Intercom
+          window.intercomSettings = {
+            app_id: "s1rasgdr"
+          };
+          var use_intercom = false;
+          document.querySelectorAll('.p-sidenav__body ul a').forEach(function(a) {
+            if (a.pathname == location.pathname) {
+              var node = a;
+              // Lists can be nested, so climb until just under the nav element
+              while (node.parentNode && node.parentNode.nodeName != "NAV") node = node.parentNode;
+              if (node.previousElementSibling.textContent == 'Publishing') {
+                // Use Intercom if this page is under Publishing in the TOC
+                use_intercom = true;
+              }
+            }
+          });
+          if (use_intercom) {
+            (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/s1rasgdr';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+          }
+
         });
       </script>
   </head>


### PR DESCRIPTION
This adds Intercom, which we're already using for https://snapcraft.io/first-snap, to the "Publishing" section of the documentation. I've talked this over with @degville and we're in agreement that having the Intercom chat window on these pages would provide us with useful research on where developer-users are getting stuck in the documentation. I do not want to open this up to all documentation pages, as that would be more traffic to Intercom than we are currently equipped to handle.