### PR TITLE
Add search endpoint

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn webapp.app:app --bind $1 --worker-class sync --workers 4 --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     echo ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,13 @@ yamlordereddictloader==0.4.0
 beautifulsoup4==4.7.1
 humanize==0.5.1
 python-dateutil==2.7.5
-gunicorn[gevent]
 talisker==0.11.1
 responses==0.10.5
+
+# TEMP FIX
+# talisker 0.11.0 has requirement Werkzeug<0.15,>=0.11.5, but you'll have werkzeug 0.15.0 which is incompatible.
+# can probably be removed when we bump talisker
+Werkzeug<0.15
 
 # Development dependencies
 black

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -21,6 +21,7 @@ discourse = DiscourseDocs(
     base_url="https://forum.snapcraft.io/",
     frontpage_id=3781,
     category_id=15,  # The "doc" category
+    category_name="doc",
 )
 
 app = flask.Flask(__name__)
@@ -114,3 +115,13 @@ def document(path):
         updated=document["updated"],
         nav_html=nav_html,
     )
+
+
+@app.route("/search")
+def search():
+    term = flask.request.args.get("term")
+    if not term:
+        return flask.jsonify({"entries": []})
+
+    search_results = discourse.search_docs(term)
+    return flask.jsonify({"entries": search_results, "term": term})

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,5 +1,6 @@
 # Core
 import re
+import urllib
 
 # Third-party
 import dateutil.parser
@@ -139,7 +140,12 @@ class DiscourseDocs:
     """
 
     def __init__(
-        self, base_url, frontpage_id, category_id, session=DEFAULT_SESSION
+        self,
+        base_url,
+        frontpage_id,
+        category_id,
+        category_name,
+        session=DEFAULT_SESSION,
     ):
         """
         @param base_url: The Discourse URL (e.g. https://discourse.example.com)
@@ -150,6 +156,7 @@ class DiscourseDocs:
         self.base_url = base_url.rstrip("/")
         self.frontpage_id = frontpage_id
         self.category_id = category_id
+        self.category_name = category_name
         self.session = session
 
     def __del__(self):
@@ -223,6 +230,13 @@ class DiscourseDocs:
             )
 
         return frontpage_document, str(nav_soup)
+
+    def search_docs(self, term):
+        q = urllib.parse.quote_plus(f"{term} #{self.category_name}")
+        search_endpoint = f"{self.base_url}/search.json?q={q}"
+        response = self.session.get(search_endpoint)
+        search_results = response.json()
+        return search_results
 
     # Private helper methods
     # ===

--- a/webapp/tests/test_models.py
+++ b/webapp/tests/test_models.py
@@ -22,6 +22,7 @@ class TestDiscourseDocs(unittest.TestCase):
             base_url="https://forum.snapcraft.io",
             frontpage_id=3781,
             category_id=15,  # The "doc" category
+            category_name="doc",
             session=self.mock_session,
         )
 
@@ -87,6 +88,7 @@ class TestDiscourseDocs(unittest.TestCase):
             base_url="https://forum.snapcraft.io",
             frontpage_id=3876,
             category_id=15,  # The "doc" category
+            category_name="doc",
             session=self.mock_session,
         )
 
@@ -203,6 +205,7 @@ class TestDiscourseDocs(unittest.TestCase):
             base_url="https://forum.snapcraft.io",
             frontpage_id=3876,
             category_id=15,  # The "doc" category
+            category_name="doc",
             session=self.mock_session,
         )
 


### PR DESCRIPTION
## Done
Added a new endpoint that searches for a term in topics of the `doc` category.

## QA
- `./run`
- `http://0.0.0.0:8030/search?term=<try_me>`
- Try a couple of search terms and make sure we get appropriate results. Category should be 15 for all the returned topics.