### PR TITLE
Adds a branded search view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ After [installing Docker](https://docs.docker.com/install/), run:
 ./run
 ```
 
+If you want to run locally with search enabled
+
+``` bash
+./run --env SEARCH_API_KEY={key}
+```
+
 And visit http://127.0.0.1:8030 in your browser.
 
 [circleci]: https://circleci.com/gh/canonical-webteam/docs.snapcraft.io "CircleCI build status"

--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn webapp.app:app --bind $1 --worker-class sync --workers 8 --name talisker-`hostname` --access-logfile -"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     echo ""

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",
-    "test-python": "coverage run --source=. -m unittest discover webapp/tests",
+    "test-python": "FLASK_DEBUG=0 coverage run --source=. -m unittest discover webapp/tests",
     "lint-python": "flake8 webapp && black --check --line-length 79 webapp",
     "lint-scss": "sass-lint static/sass/**/*.scss --verbose --no-exit",
     "build": "yarn run build-css && yarn run build-js",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # App dependencies
+talisker==0.11.1
 Flask==1.0.2
 canonicalwebteam.http==0.1.6
 canonicalwebteam.yaml_responses[flask]==1.1.0
@@ -8,10 +9,10 @@ yamlordereddictloader==0.4.0
 beautifulsoup4==4.7.1
 humanize==0.5.1
 python-dateutil==2.7.5
-gunicorn[gevent]
-talisker==0.11.1
 responses==0.10.5
 
 # Development dependencies
 black
+blinker # Flask-Testing is not pulling it
 coverage
+Flask-Testing==0.7.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
+      {% block meta %}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+      {% endblock %}
 
-      <title>{% if title %}{{ title }} - {% endif %}Documentation for snaps: Universal Linux packages</title>
-
+      {% block title %}
+        <title>{% if title %}{{ title }} - {% endif %}Documentation for snaps: Universal Linux packages</title>
+      {% endblock %}
       <!-- Google Tag Manager -->
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -126,11 +129,10 @@
 
     <section id="search-docs" class="p-strip--image is-shallow snapcraft-banner-background">
       <div class="row">
-        <form class="p-search-box u-no-margin--bottom" style="box-shadow: none" action="https://www.ubuntu.com/search">
-          <input type="hidden" name="siteSearch" value="docs.snapcraft.io" />
-          <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required />
+        <form class="p-search-box u-no-margin--bottom" style="box-shadow: none" action="/search">
+          <input type="search" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
           <button type="reset" class="p-search-box__reset" alt="reset" style="right: 6.7rem"><i class="p-icon--close"></i></button>
-          <button type="submit" class="p-button--positive u-no-margin--bottom p-link--external" style="margin-left: 1.5rem; width: auto" alt="search">Search</button>
+          <button type="submit" class="p-button--positive u-no-margin--bottom" style="margin-left: 1.5rem; width: auto" alt="search">Search</button>
         </form>
       </div>
     </section>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+
+{% block meta %}
+    {{ super() }}
+    <meta name="robots" content="noindex" />
+{% endblock %}
+
+{% block title %}
+    <title>Search results{% if query %} for "{{query}}"{% endif %} | Documentation for snaps: Universal Linux packages</title>
+{% endblock %}
+
+{% block body %}
+  <div class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row">
+      <div class="col-12">
+        {% if results and results.entries %}
+          <h1 class="p-heading--two u-no-margin--bottom">We've found these results for your search <strong>"{{ query }}"</strong></h1>
+        {% else %}
+          <h1 class="p-heading--two u-no-margin--bottom">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {% if  results and results.entries %}
+      {% for item in results.entries %}
+      <div class="p-strip is-bordered is-shallow">
+        <div class="row">
+          <div class="col-12">
+            <h5><a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe}}</a></h5>
+            <p>
+              {{ item.htmlSnippet | safe }}
+            </p>
+            <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+      <div class="p-strip p-pagination">
+          {% if  results.queries and results.queries.previousPage %}
+              <a
+                class="p-pagination__link--previous"
+                href="/search?q={{ query }}&amp;num={{ num }}&amp;start={{ results.queries.previousPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+              >
+                  <span class="p-pagination__label">Previous</span>
+              </a>
+          {% endif %}
+          {% if results.queries and results.queries.nextPage %}
+            <a
+              class="p-pagination__link--next"
+              href="/search?q={{ query }}&amp;num={{ num }}&amp;start={{ results.queries.nextPage.0.startIndex }}{% if siteSearch %}&amp;siteSearch={{ siteSearch }}{% endif %}"
+            >
+              <span class="p-pagination__label">Next</span>
+            </a>
+          {% endif %}
+      </div>
+  {% else %}
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-6">
+        <h3>Why not try widening your search?</h3>
+        <p>You can do this by:</p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
+          <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
+          <li class="p-list__item is-ticked">Trying a different spelling</li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <h3>Still no luck?</h3>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked"><a href="/">Visit docs.snapcraft.io</a></li>
+          <li class="p-list__item is-ticked"><a href="https://forum.snapcraft.io">Ask on the forum</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+{% endblock body %}
+

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -13,6 +13,7 @@ from jinja2 import Template
 
 # Constants
 DEFAULT_SESSION = CachedSession(expire_after=300, old_data_on_error=True)
+SEARCH_SESSION = CachedSession(expire_after=600)
 
 
 class RedirectFoundError(HTTPError):
@@ -278,3 +279,44 @@ class DiscourseDocs:
             raise error
 
         return response.json()
+
+
+class NoAPIKeyError(Exception):
+    pass
+
+
+def get_search_results(
+    api_key,
+    api_url,
+    search_custom_id,
+    query,
+    start,
+    num,
+    session=SEARCH_SESSION,
+):
+    """
+    Query the Google Custom Search API for search results
+    """
+    if not api_key:
+        raise NoAPIKeyError("Unable to search: No API key provided")
+
+    results = session.get(
+        api_url,
+        params={
+            "key": api_key,
+            "cx": search_custom_id,
+            "q": query,
+            "siteSearch": "docs.snapcraft.io",
+            "start": start,
+            "num": num,
+        },
+    ).json()
+
+    if "items" in results:
+        # Move "items" to "entries" as "items" is a method name for dicts
+        # and it causes wierd things to happen in Jinja2
+        results["entries"] = results.pop("items")
+        for item in results["entries"]:
+            item["htmlSnippet"] = item["htmlSnippet"].replace("<br>\n", "")
+
+    return results

--- a/webapp/tests/test_models.py
+++ b/webapp/tests/test_models.py
@@ -2,11 +2,14 @@
 import unittest
 
 # Modules
+import responses
 import requests_mock
+from flask_testing import TestCase
 from requests import Session
 from requests.exceptions import HTTPError
 
 # Local
+from webapp.app import app
 from webapp import models
 from webapp.tests.fixtures.snapcraft_forum_mock import register_uris
 
@@ -219,6 +222,121 @@ class TestDiscourseDocs(unittest.TestCase):
         self.assertFalse("NOTE TO EDITORS" in doc["body_html"])
         self.assertTrue("<p>The following sections" in doc["body_html"])
         self.assertTrue(doc["forum_link"] in str(context.exception))
+
+
+class TestGoogleSearchApi(unittest.TestCase):
+    def setUp(self):
+        self.mock_session = Session()
+        google_api_mock_adapter = requests_mock.Adapter()
+        google_api_mock_adapter.register_uri(
+            "GET",
+            (
+                "https://www.googleapis.com/customsearch/v1"
+                "?key=key&cx=cx&q=q&start=start&num=num"
+                "&siteSearch=docs.snapcraft.io"
+            ),
+            json={
+                "items": [{"htmlSnippet": "<br>\n"}, {"htmlSnippet": "<br>\n"}]
+            },
+        )
+        self.mock_session.mount("https://", google_api_mock_adapter)
+
+    def test_replace_line_breaks(self):
+        results = models.get_search_results(
+            "key",
+            "https://www.googleapis.com/customsearch/v1?",
+            "cx",
+            "q",
+            "start",
+            "num",
+            session=self.mock_session,
+        )
+
+        self.assertEqual(
+            {"entries": [{"htmlSnippet": ""}, {"htmlSnippet": ""}]}, results
+        )
+
+    def test_raise_no_api_key_error(self):
+        with self.assertRaises(models.NoAPIKeyError):
+            models.get_search_results(
+                None,
+                "https://www.googleapis.com/customsearch/v1?",
+                "cx",
+                "q",
+                "start",
+                "num",
+                session=self.mock_session,
+            )
+
+
+class TestSearchViewNoApiKey(TestCase):
+    def create_app(self):
+        test_app = app
+        test_app.testing = True
+        test_app.config["SEARCH_API_KEY"] = None
+        return test_app
+
+    def test_no_api_key_500(self):
+        with self.assertRaises(models.NoAPIKeyError):
+            self.client.get("/search?q=test")
+
+
+class TestSearchView(TestCase):
+    def create_app(self):
+        test_app = app
+        test_app.testing = True
+        test_app.config["SEARCH_API_KEY"] = "test"
+        return test_app
+
+    @responses.activate
+    def test_search_no_results(self):
+        responses.add(
+            responses.GET,
+            (
+                "https://www.googleapis.com/customsearch/v1"
+                "?key=test"
+                "&cx=009048213575199080868:i3zoqdwqk8o"
+                "&q=nothing"
+                "&start=1"
+                "&num=10"
+                "&siteSearch=docs.snapcraft.io"
+            ),
+            json={"items": []},
+        )
+
+        response = self.client.get("/search?q=nothing")
+        self.assert200(response)
+        self.assertContext("query", "nothing")
+        self.assertContext("start", 1)
+        self.assertContext("num", 10)
+        self.assertContext("results", {"entries": []})
+
+    @responses.activate
+    def test_search(self):
+        responses.add(
+            responses.GET,
+            (
+                "https://www.googleapis.com/customsearch/v1"
+                "?key=test"
+                "&cx=009048213575199080868:i3zoqdwqk8o"
+                "&q=everything"
+                "&start=1"
+                "&num=10"
+                "&siteSearch=docs.snapcraft.io"
+            ),
+            json={
+                "items": [{"htmlSnippet": "<br>\n"}, {"htmlSnippet": "<br>\n"}]
+            },
+        )
+
+        response = self.client.get("/search?q=everything")
+        self.assert200(response)
+        self.assertContext("query", "everything")
+        self.assertContext("start", 1)
+        self.assertContext("num", 10)
+        self.assertContext(
+            "results", {"entries": [{"htmlSnippet": ""}, {"htmlSnippet": ""}]}
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Done
Adds a branded search view that works the same way has the one in www.ubuntu.com.

## QA
- Grab the key from the google api console.
- ./run --env SEARCH_API_KEY={key} (ask me for the key if you don't have access)
- Try to use the search bar.

## Issues
Fixes #129  