### PR TITLE
Update footer support links again

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -172,7 +172,7 @@
               or
               <a
                 class="p-link--external"
-                href="https://github.com/canonical-websites/snapcraft.io/issues"
+                href="https://github.com/canonical-websites/docs.snapcraft.io/issues"
               >this site</a>.
             </small>
           </p>


### PR DESCRIPTION
Re-fixes #52 by pointing to this repo, not generic snapcraft.io for bugs.

## QA

./run, go to http://0.0.0.0:8030/t/snap-documentation/3781, read the footer and make sure it makes sense and the links go sensible places.