### PR TITLE
Make titles display properly

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
       {% endblock %}
 
-      <title>{% if self.title() %}{% block title %}{% endblock %} - {% endif %}Documentation for snaps: Universal Linux packages</title>
+      <title>{% if self.title() and self.title() != 'Snap Documentation' %}{% block title %}{% endblock %} - {% endif %}Snap documentation</title>
 
       <!-- Google Tag Manager -->
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/templates/document.html
+++ b/templates/document.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}{{ document.title }}{% endblock %}
+
 {% block body %}
   <aside class="l-docs-sidebar" id="navigation">
     <i class="p-sidenav__toggle p-icon--menu u-hide u-show--small"></i>


### PR DESCRIPTION
QA
--

Go to the homepage, see the title says "Snap documentation".

Go to any other page, see the title says "{title} - Snap documentation".